### PR TITLE
Add SetFit to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psutil==5.9.0
 deepspeed==0.5.10
 sentencepiece==0.1.96
 ipdb
+setfit==0.5.0


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add `setfit==0.5.0` to requirements.

## Details
See https://github.com/huggingface/setfit/pull/285 for details.
If we fix the requirements to 0.5.0, then `Benchmark` and `load_data_splits` could be removed from SetFit in later versions. After all, this class and function are not used in SetFit internally.

cc: @danielkorat

- Tom Aarsen
